### PR TITLE
arena fix: regex replace all space areas to tdome areas

### DIFF
--- a/_maps/toolbox_arenas/arena_ballin.dmm
+++ b/_maps/toolbox_arenas/arena_ballin.dmm
@@ -8,7 +8,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "bL" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/corner{
@@ -18,7 +18,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ca" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
@@ -31,7 +31,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cz" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -44,7 +44,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cV" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -54,7 +54,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "dt" = (
 /obj/effect/turf_decal/trimline/dark,
 /obj/effect/turf_decal/trimline/dark/mid_joiner,
@@ -73,19 +73,19 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/dirt,
-/area/space)
+/area/centcom/tdome/arena)
 "eu" = (
 /obj/structure/hoop,
 /obj/effect/turf_decal/trimline/neutral/end,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/centcom/tdome/arena)
 "eG" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "fW" = (
 /obj/effect/turf_decal/siding/thinplating_new/corner,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -94,13 +94,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "gI" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "hp" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -108,7 +108,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "hP" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -117,7 +117,7 @@
 /obj/structure/rack,
 /obj/item/stack/package_wrap,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "hS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -126,7 +126,7 @@
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "iY" = (
 /obj/structure/flora/tree/dead/style_4{
 	pixel_x = -19;
@@ -145,13 +145,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/dirt,
-/area/space)
+/area/centcom/tdome/arena)
 "jb" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_edge,
-/area/space)
+/area/centcom/tdome/arena)
 "ji" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
@@ -160,7 +160,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "jx" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -171,7 +171,7 @@
 	},
 /obj/item/chair/plastic,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ke" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
@@ -186,21 +186,21 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "kr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "ks" = (
 /obj/structure/hedge,
 /obj/structure/fence/cut/large{
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space)
+/area/centcom/tdome/arena)
 "kD" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 9
@@ -208,19 +208,19 @@
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "ms" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_edge,
-/area/space)
+/area/centcom/tdome/arena)
 "mR" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor4-old"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "mV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -229,21 +229,21 @@
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "nS" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "oK" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ph" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
@@ -256,7 +256,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "pB" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /obj/item/ammo_casing{
@@ -264,7 +264,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "pJ" = (
 /obj/effect/turf_decal/siding/thinplating_new/corner{
 	dir = 1
@@ -274,7 +274,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qf" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -284,14 +284,14 @@
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "qG" = (
 /obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/turf_decal/trimline/dark/corner{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qM" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -301,7 +301,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qT" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -309,7 +309,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/corner,
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "rb" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -320,7 +320,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "rY" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -331,7 +331,7 @@
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "sf" = (
 /obj/effect/turf_decal/siding/thinplating_new/corner{
 	dir = 4
@@ -347,7 +347,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "sk" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
@@ -357,7 +357,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "sn" = (
 /obj/item/newspaper{
 	pixel_x = 5;
@@ -372,7 +372,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ta" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -382,7 +382,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "ts" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -393,7 +393,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "tH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -405,7 +405,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/iron/dark/textured_corner,
-/area/space)
+/area/centcom/tdome/arena)
 "uv" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -416,7 +416,7 @@
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "vx" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -427,7 +427,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "vA" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -442,7 +442,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "vQ" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -450,7 +450,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "wz" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor7-old"
@@ -458,7 +458,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "xB" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -470,22 +470,22 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "xH" = (
 /turf/open/floor/iron/dark/textured_half,
-/area/space)
+/area/centcom/tdome/arena)
 "ym" = (
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "yv" = (
 /obj/structure/grille,
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "yE" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -493,14 +493,14 @@
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "yI" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "zp" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -508,7 +508,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "zK" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 10
@@ -517,7 +517,7 @@
 	dir = 10
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Aj" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
@@ -525,30 +525,30 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "AC" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/centcom/tdome/arena)
 "Bj" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Br" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "BQ" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "BW" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -558,7 +558,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "BY" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -569,7 +569,7 @@
 	icon_state = "floor4-old"
 	},
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "Cy" = (
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 4
@@ -579,7 +579,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/centcom/tdome/arena)
 "CC" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -592,7 +592,7 @@
 	},
 /mob/living/basic/cockroach,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "CP" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -604,7 +604,7 @@
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "Dq" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -615,14 +615,14 @@
 	},
 /obj/effect/turf_decal/trimline/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "DG" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "DH" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -630,7 +630,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "DP" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -638,7 +638,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "Ec" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -646,7 +646,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "EA" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -657,13 +657,13 @@
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "EM" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Ge" = (
 /obj/structure/fence{
 	dir = 4
@@ -672,7 +672,7 @@
 	icon_state = "ghost"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "Ha" = (
 /obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/decal/cleanable/garbage{
@@ -680,7 +680,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Hy" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
@@ -692,7 +692,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "HM" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -700,7 +700,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "HP" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -712,7 +712,7 @@
 	},
 /obj/structure/table_frame,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "HU" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -724,7 +724,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "HZ" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -739,7 +739,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ij" = (
 /obj/structure/fence{
 	dir = 4
@@ -749,7 +749,7 @@
 	},
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "In" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 5
@@ -758,7 +758,7 @@
 	dir = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ix" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -766,7 +766,7 @@
 	},
 /obj/structure/holosign/barrier,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "IF" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -778,7 +778,7 @@
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "IO" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
@@ -792,7 +792,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/space)
+/area/centcom/tdome/arena)
 "Je" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -802,34 +802,34 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Jn" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "JS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "KA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "KL" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "KS" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -837,7 +837,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Lk" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
@@ -846,7 +846,7 @@
 	dir = 6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ll" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "Psyke"
@@ -854,13 +854,13 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "LD" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "LN" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -868,7 +868,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "LP" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
@@ -882,7 +882,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ma" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -890,7 +890,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "MT" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
@@ -900,7 +900,7 @@
 	},
 /mob/living/basic/cockroach,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "MU" = (
 /obj/structure/flora/tree/dead{
 	pixel_x = -18;
@@ -922,10 +922,10 @@
 	icon_state = "floor5-old"
 	},
 /turf/open/misc/dirt,
-/area/space)
+/area/centcom/tdome/arena)
 "Nv" = (
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "NY" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -933,7 +933,7 @@
 	},
 /obj/structure/closet/cardboard,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "Ob" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 9
@@ -942,7 +942,7 @@
 	dir = 9
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ou" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -952,14 +952,14 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "OA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "OC" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
@@ -967,7 +967,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "OH" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -980,7 +980,7 @@
 	pixel_y = 18
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Pm" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -992,7 +992,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Po" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
@@ -1001,7 +1001,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/centcom/tdome/arena)
 "Px" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -1009,13 +1009,13 @@
 	},
 /obj/structure/fans,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "PA" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/centcom/tdome/arena)
 "Qv" = (
 /obj/effect/turf_decal/siding/thinplating_new/corner{
 	dir = 8
@@ -1029,7 +1029,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "QE" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -1041,12 +1041,12 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Rc" = (
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Rq" = (
 /obj/item/trash/ready_donk{
 	pixel_y = 8
@@ -1056,7 +1056,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "RS" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -1065,7 +1065,7 @@
 /obj/machinery/icecream_vat,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "RT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/corner{
@@ -1074,7 +1074,7 @@
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Sc" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
@@ -1082,7 +1082,7 @@
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "SX" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -1094,7 +1094,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "TU" = (
 /obj/item/toy/basketball{
 	pixel_x = -8;
@@ -1105,14 +1105,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/centcom/tdome/arena)
 "Uz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "UA" = (
 /obj/structure/hoop{
 	dir = 1
@@ -1121,20 +1121,20 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/centcom/tdome/arena)
 "UU" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "Newton"
 	},
 /turf/open/floor/iron/dark/textured_edge,
-/area/space)
+/area/centcom/tdome/arena)
 "Wr" = (
 /obj/structure/hedge,
 /obj/structure/fence/cut/medium{
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space)
+/area/centcom/tdome/arena)
 "Wt" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
@@ -1142,12 +1142,12 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "WE" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "WV" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -1158,7 +1158,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Xf" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -1168,7 +1168,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Xy" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -1180,18 +1180,18 @@
 	},
 /obj/item/usb_cable,
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "XK" = (
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "XL" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "XP" = (
 /obj/structure/fence{
 	dir = 4
@@ -1201,11 +1201,11 @@
 	pixel_y = -5
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "YY" = (
 /obj/effect/turf_decal/trimline/neutral/corner,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Zu" = (
 /obj/effect/turf_decal/trimline/dark,
 /obj/effect/turf_decal/trimline/dark/mid_joiner,
@@ -1223,7 +1223,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/dirt,
-/area/space)
+/area/centcom/tdome/arena)
 "ZJ" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -1236,7 +1236,7 @@
 	pixel_y = 16
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 
 (1,1,1) = {"
 ta

--- a/_maps/toolbox_arenas/arena_chains.dmm
+++ b/_maps/toolbox_arenas/arena_chains.dmm
@@ -5,7 +5,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "aT" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/trimline/dark,
@@ -13,7 +13,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "bo" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
@@ -22,7 +22,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "bJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/mask/cigarette/cigar{
@@ -33,7 +33,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "bY" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -46,7 +46,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "cc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/corner{
@@ -56,11 +56,11 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cm" = (
 /obj/structure/table,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -68,7 +68,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "cS" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -77,7 +77,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "dy" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -85,7 +85,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "fp" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -95,24 +95,24 @@
 	},
 /obj/effect/turf_decal/trimline/dark,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "ft" = (
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "fw" = (
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 10
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "fB" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/trimline/dark/corner{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ie" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/warning{
@@ -122,7 +122,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "iW" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
@@ -131,7 +131,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "jg" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -141,7 +141,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "jp" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -150,14 +150,14 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "jq" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "jt" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -167,7 +167,7 @@
 	},
 /obj/effect/turf_decal/caution/white,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "jy" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -177,7 +177,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "kr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -186,11 +186,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "kw" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "kx" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
@@ -199,16 +199,16 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "kI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "kU" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "lk" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -218,7 +218,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "lq" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -228,7 +228,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "mG" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -239,7 +239,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "mI" = (
 /obj/item/ammo_casing,
 /obj/item/ammo_casing{
@@ -250,13 +250,13 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "mM" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "nu" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -266,7 +266,7 @@
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "nP" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -276,14 +276,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "nR" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "oG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/spacecash/c50{
@@ -296,7 +296,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "oR" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -304,7 +304,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "ql" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -314,13 +314,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "qn" = (
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/head/fedora,
@@ -328,34 +328,34 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/corner{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qH" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "rD" = (
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "sb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "sk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/head/cone{
@@ -368,7 +368,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "tI" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -377,26 +377,26 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "tL" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "tV" = (
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "uj" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "uQ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/decal/cleanable/crayon{
@@ -404,27 +404,27 @@
 	pixel_x = -10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "vs" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "vJ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/white,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "vK" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "vS" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -435,7 +435,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "wi" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4;
@@ -445,7 +445,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ww" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -458,7 +458,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "xr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -469,27 +469,27 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "yb" = (
 /obj/item/toy/crayon/white{
 	pixel_x = 17
 	},
 /obj/effect/turf_decal/trimline/dark/warning,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "AZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "BJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 9
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "BU" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -500,7 +500,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Cm" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -513,25 +513,25 @@
 	},
 /obj/effect/turf_decal/trimline/dark,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "CX" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Du" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/ammo_casing,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Dv" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/closed/wall{
 	opacity = 0
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "DA" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -539,11 +539,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Fq" = (
 /obj/effect/turf_decal/trimline/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Fw" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/decal/cleanable/crayon{
@@ -561,7 +561,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "FX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/head/cone{
@@ -569,11 +569,11 @@
 	pixel_y = 6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Gq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "GE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/gun{
@@ -587,23 +587,23 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "HK" = (
 /obj/structure/closet/body_bag,
 /obj/effect/turf_decal/trimline/dark/corner{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Is" = (
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "It" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall{
 	opacity = 0
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Iw" = (
 /obj/item/clothing/head/cone{
 	pixel_x = -2;
@@ -615,14 +615,14 @@
 	pixel_y = 3
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "IQ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/caution/white{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "IY" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4;
@@ -632,13 +632,13 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Jr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "JH" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -652,12 +652,12 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Kr" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fans/tiny,
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/centcom/tdome/arena)
 "Kw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/dark/warning{
@@ -667,14 +667,14 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Li" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Lp" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
@@ -683,7 +683,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Mr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -696,7 +696,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "NS" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
@@ -705,7 +705,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Pe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/dark/corner,
@@ -713,7 +713,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Qh" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
@@ -723,7 +723,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Qu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/blood_geometer{
@@ -733,7 +733,7 @@
 /turf/closed/wall{
 	opacity = 0
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "RO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/safe,
@@ -744,21 +744,21 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "RP" = (
 /obj/item/clothing/head/cone{
 	pixel_x = 3;
 	pixel_y = -6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "RU" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "SA" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -769,34 +769,34 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "SY" = (
 /obj/structure/table_frame,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Tn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Tz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "TS" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "UO" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "VS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/crayon{
@@ -806,7 +806,7 @@
 /turf/closed/wall{
 	opacity = 0
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "WI" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -815,7 +815,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "XY" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -823,7 +823,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Yg" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -831,19 +831,19 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/turf_decal/caution/white,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "YE" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/centcom/tdome/arena)
 "Za" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 
 (1,1,1) = {"
 Fw

--- a/_maps/toolbox_arenas/arena_conveyor.dmm
+++ b/_maps/toolbox_arenas/arena_conveyor.dmm
@@ -5,22 +5,22 @@
 	pixel_y = -10
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "aP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "aV" = (
 /obj/effect/turf_decal/syndicateemblem/top/left,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "bQ" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "bR" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -33,7 +33,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cB" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -42,40 +42,40 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cQ" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ek" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "fi" = (
 /obj/effect/turf_decal/syndicateemblem/top/right,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "gA" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "gB" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "gI" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/right,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "gM" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
@@ -85,7 +85,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "gO" = (
 /obj/effect/turf_decal/syndicateemblem/middle/left,
 /obj/effect/turf_decal/siding/dark/corner{
@@ -93,23 +93,23 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "he" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "ic" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "lz" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "nV" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -118,7 +118,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "nW" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
@@ -127,16 +127,16 @@
 	dir = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ot" = (
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "oB" = (
 /obj/machinery/conveyor{
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ps" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
@@ -144,13 +144,13 @@
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "pL" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "qQ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -164,7 +164,7 @@
 	pixel_y = -4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "si" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -173,11 +173,11 @@
 	pixel_x = -2
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "sK" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/middle,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "tr" = (
 /obj/item/clothing/head/cone{
 	pixel_x = 6;
@@ -188,7 +188,7 @@
 	pixel_y = -4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "tK" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -201,43 +201,43 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "wW" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "xx" = (
 /obj/structure/fluff/big_chain,
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "xF" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "yb" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/left,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "zR" = (
 /obj/item/ammo_casing/spent{
 	pixel_x = -5;
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "AG" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "By" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -251,24 +251,24 @@
 	pixel_y = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Df" = (
 /obj/structure/fluff/big_chain,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "Dl" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Do" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "DS" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -281,7 +281,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "DY" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/item/cigbutt{
@@ -289,7 +289,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "EA" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -300,89 +300,89 @@
 	pixel_y = 13
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Fq" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "GW" = (
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Hc" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "Hh" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "HD" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "HL" = (
 /obj/effect/turf_decal/syndicateemblem/middle/middle,
 /obj/machinery/conveyor_switch/oneway{
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "HR" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ii" = (
 /obj/item/cigbutt{
 	pixel_x = -11;
 	pixel_y = 15
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "IF" = (
 /obj/structure/closet/crate/preopen,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "JP" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "MS" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "NH" = (
 /obj/machinery/conveyor/inverted{
 	dir = 6;
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "NQ" = (
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "NV" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "Oz" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -390,7 +390,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "OF" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -400,12 +400,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Pt" = (
 /turf/closed/wall{
 	opacity = 0
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "QI" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/siding/dark{
@@ -416,43 +416,43 @@
 	pixel_y = 15
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "QW" = (
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "Rc" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Rt" = (
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "Rw" = (
 /obj/effect/turf_decal/syndicateemblem/middle/right,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Rx" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Si" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Te" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "TI" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -463,7 +463,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ut" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/cigbutt{
@@ -471,13 +471,13 @@
 	pixel_y = 15
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "UL" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "UT" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -487,18 +487,18 @@
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/space)
+/area/centcom/tdome/arena)
 "Xh" = (
 /obj/effect/turf_decal/syndicateemblem/top/middle,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "XT" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "WarehouseEVENT"
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 
 (1,1,1) = {"
 JP

--- a/_maps/toolbox_arenas/arena_office.dmm
+++ b/_maps/toolbox_arenas/arena_office.dmm
@@ -9,13 +9,13 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "bd" = (
 /obj/structure/stairs/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "bo" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/smartfridge/food{
@@ -26,7 +26,7 @@
 	},
 /obj/structure/sign/clock/directional/south,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "bQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass{
@@ -39,7 +39,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/iron/dark/small,
-/area/space)
+/area/centcom/tdome/arena)
 "cQ" = (
 /obj/structure/railing{
 	dir = 8
@@ -48,7 +48,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -66,7 +66,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "ej" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -75,7 +75,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "ek" = (
 /obj/structure/table_frame/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -83,10 +83,10 @@
 	pixel_x = 5
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/centcom/tdome/arena)
 "ew" = (
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "ey" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -95,7 +95,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "fr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -109,13 +109,13 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "fy" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "fJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -135,7 +135,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "gA" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/wood{
@@ -145,7 +145,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "gG" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -160,7 +160,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "gK" = (
 /obj/structure/table/wood,
 /obj/item/newspaper{
@@ -179,7 +179,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "hs" = (
 /obj/item/chair/wood{
 	dir = 4;
@@ -188,7 +188,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "iv" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -203,7 +203,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "iK" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1;
@@ -213,7 +213,7 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "jh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -227,7 +227,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "jo" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -236,7 +236,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "kq" = (
 /obj/item/photo/old{
 	pixel_x = -7
@@ -245,12 +245,12 @@
 	pixel_y = -3
 	},
 /turf/closed/wall/mineral/wood,
-/area/space)
+/area/centcom/tdome/arena)
 "kI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
-/area/space)
+/area/centcom/tdome/arena)
 "kN" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -260,7 +260,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "kS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -274,7 +274,7 @@
 	pixel_y = 19
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "ln" = (
 /obj/structure/fluff/paper/stack{
 	dir = 1;
@@ -285,14 +285,14 @@
 	dir = 6
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "lM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "md" = (
 /obj/item/chair/stool/bar{
 	pixel_y = -6
@@ -304,7 +304,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "mq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -314,14 +314,14 @@
 	pixel_y = -5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "mA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "na" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1;
@@ -329,14 +329,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "nF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "od" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -344,25 +344,25 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "oj" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
 	},
 /obj/structure/railing/corner/end,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ow" = (
 /obj/item/wallframe/telescreen/entertainment,
 /turf/closed/wall/mineral/wood,
-/area/space)
+/area/centcom/tdome/arena)
 "oy" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1;
 	pixel_y = 7
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "oA" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/ammo_casing{
@@ -380,7 +380,7 @@
 	},
 /obj/structure/sign/poster/contraband/blood_geometer/directional/south,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "oG" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -401,7 +401,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "pD" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -410,7 +410,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "pL" = (
 /obj/effect/decal/cleanable/glass{
 	icon_state = "ants_2_light";
@@ -418,7 +418,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/dirt,
-/area/space)
+/area/centcom/tdome/arena)
 "pS" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -428,7 +428,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "pZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/bed/double,
@@ -439,7 +439,7 @@
 	pixel_y = -27
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "qf" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -449,7 +449,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "qi" = (
 /obj/structure/railing{
 	dir = 1
@@ -458,7 +458,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qC" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -474,11 +474,11 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "rf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/dirt,
-/area/space)
+/area/centcom/tdome/arena)
 "rp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -487,7 +487,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "rv" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
@@ -500,7 +500,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "rT" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -516,14 +516,14 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "sO" = (
 /obj/item/clothing/head/fedora{
 	pixel_x = 1;
 	pixel_y = -1
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "to" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -538,7 +538,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "tJ" = (
 /obj/item/ammo_casing{
 	dir = 10;
@@ -548,7 +548,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "ua" = (
 /obj/item/plate_shard{
 	pixel_x = 3;
@@ -570,7 +570,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/centcom/tdome/arena)
 "uk" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/wood{
@@ -580,7 +580,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "uL" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -589,7 +589,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "vc" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
@@ -607,7 +607,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "wK" = (
 /obj/structure/fluff/paper/stack{
 	dir = 6;
@@ -620,14 +620,14 @@
 	pixel_x = -19
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "xg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "xy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/paper/stack{
@@ -639,12 +639,12 @@
 	pixel_y = -12
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "xP" = (
 /obj/effect/turf_decal/trimline/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
-/area/space)
+/area/centcom/tdome/arena)
 "yo" = (
 /obj/structure/bookcase,
 /obj/effect/turf_decal/siding/wood{
@@ -659,7 +659,7 @@
 	pixel_y = 18
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "ys" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/grille/broken,
@@ -678,13 +678,13 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/centcom/tdome/arena)
 "yH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "yM" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -699,7 +699,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "yV" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
@@ -718,7 +718,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "zH" = (
 /obj/item/chair/wood{
 	pixel_x = 6;
@@ -726,13 +726,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "BN" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/crate/bin,
 /obj/structure/sign/poster/contraband/kss13/directional/south,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "BU" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/glass{
@@ -743,7 +743,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/centcom/tdome/arena)
 "Cp" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/wood{
@@ -754,7 +754,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "CW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -764,7 +764,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "CY" = (
 /obj/structure/fluff/paper/corner{
 	dir = 4
@@ -778,7 +778,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Dn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -789,7 +789,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "DC" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -798,7 +798,7 @@
 /obj/effect/turf_decal/trimline/dark/warning,
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/dark/smooth_edge,
-/area/space)
+/area/centcom/tdome/arena)
 "DW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
@@ -806,7 +806,7 @@
 	color = "#993333"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/centcom/tdome/arena)
 "DZ" = (
 /obj/structure/fireplace{
 	pixel_y = 1
@@ -830,7 +830,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ED" = (
 /obj/effect/decal/cleanable/glass{
 	icon_state = "ants_4_light";
@@ -841,7 +841,7 @@
 	dir = 9
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Ft" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -850,11 +850,11 @@
 	pixel_y = 7
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Fw" = (
 /obj/effect/turf_decal/trimline/dark,
 /turf/open/floor/iron/dark/small,
-/area/space)
+/area/centcom/tdome/arena)
 "FH" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
@@ -872,7 +872,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "FR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -881,7 +881,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Gs" = (
 /obj/item/photo/old{
 	pixel_x = 16;
@@ -893,7 +893,7 @@
 	},
 /obj/item/photo/old,
 /turf/closed/wall/mineral/wood,
-/area/space)
+/area/centcom/tdome/arena)
 "HU" = (
 /obj/item/cigbutt{
 	pixel_x = 4;
@@ -903,7 +903,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "JF" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -912,7 +912,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table_frame,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/space)
+/area/centcom/tdome/arena)
 "LG" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/wood{
@@ -922,7 +922,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "LH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -944,7 +944,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Mc" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -953,7 +953,7 @@
 	dir = 6
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Mo" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -964,12 +964,12 @@
 	pixel_y = 3
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Mz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /turf/open/misc/dirt,
-/area/space)
+/area/centcom/tdome/arena)
 "MQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -980,7 +980,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "MX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/cloth{
@@ -988,7 +988,7 @@
 	icon_state = "bathroom-closed"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/centcom/tdome/arena)
 "Nf" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/dresser,
@@ -997,17 +997,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Ob" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Ok" = (
 /turf/closed/wall/mineral/wood,
-/area/space)
+/area/centcom/tdome/arena)
 "OE" = (
 /obj/structure/noticeboard/directional/north{
 	pixel_x = 4;
@@ -1030,7 +1030,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "OW" = (
 /obj/structure/chair/office{
 	dir = 1;
@@ -1040,7 +1040,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Pg" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -1053,7 +1053,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Qd" = (
 /obj/structure/noticeboard/directional/north{
 	pixel_x = -4;
@@ -1076,15 +1076,15 @@
 	pixel_y = 10
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Qn" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Qt" = (
 /obj/item/cigbutt,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "Qy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -1092,7 +1092,7 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "QQ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -1113,14 +1113,14 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "QZ" = (
 /obj/item/clothing/neck/tie/detective{
 	pixel_x = -6;
 	pixel_y = -4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Rr" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_y = 14
@@ -1133,7 +1133,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Sh" = (
 /obj/effect/decal/cleanable/glass{
 	icon_state = "ants_4_light";
@@ -1149,13 +1149,13 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "Sk" = (
 /obj/structure/sign/plaques/kiddie{
 	icon_state = "map-CS"
 	},
 /turf/closed/wall/mineral/wood,
-/area/space)
+/area/centcom/tdome/arena)
 "SK" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -1164,13 +1164,13 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Tn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Tz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1180,7 +1180,7 @@
 	pixel_y = -10
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Ue" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/structure/chair/stool/bar/directional/west{
@@ -1194,16 +1194,16 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Um" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "UY" = (
 /obj/structure/sign/plaques/kiddie,
 /turf/closed/wall/mineral/wood,
-/area/space)
+/area/centcom/tdome/arena)
 "Vj" = (
 /obj/structure/table/wood,
 /obj/structure/showcase/machinery/tv,
@@ -1211,13 +1211,13 @@
 	dir = 9
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Vl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Vq" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
@@ -1231,29 +1231,29 @@
 	},
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Vw" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "VR" = (
 /obj/item/ammo_casing{
 	dir = 10;
 	pixel_y = -4
 	},
 /turf/open/misc/dirt,
-/area/space)
+/area/centcom/tdome/arena)
 "Wa" = (
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/iron/dark/small,
-/area/space)
+/area/centcom/tdome/arena)
 "Wd" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ww" = (
 /obj/structure/fluff/paper/stack{
 	dir = 5;
@@ -1264,7 +1264,7 @@
 	pixel_y = -16
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "WL" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
@@ -1279,7 +1279,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark/smooth_corner,
-/area/space)
+/area/centcom/tdome/arena)
 "Xa" = (
 /obj/effect/decal/cleanable/glass{
 	icon_state = "ants_2_light";
@@ -1290,14 +1290,14 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/centcom/tdome/arena)
 "Xo" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/filingcabinet,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "Xs" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -1314,7 +1314,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "XR" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/wood{
@@ -1324,11 +1324,11 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "YB" = (
 /obj/machinery/door/airlock/wood/glass,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "YE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1338,7 +1338,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 "ZN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -1348,7 +1348,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/centcom/tdome/arena)
 
 (1,1,1) = {"
 UY

--- a/_maps/toolbox_arenas/arena_premonition.dmm
+++ b/_maps/toolbox_arenas/arena_premonition.dmm
@@ -8,7 +8,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "bb" = (
 /obj/effect/turf_decal/weather/sand{
 	color = "#662e2b";
@@ -17,7 +17,7 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "bd" = (
 /obj/structure/mannequin/plastic,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -25,42 +25,42 @@
 	name = "Dies-To-Premonitions"
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "cd" = (
 /obj/structure/flora/grass/green,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "db" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "dj" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "fR" = (
 /obj/structure/flora/grass/both/style_2,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "hc" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "hE" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "iv" = (
 /obj/structure/sign/flag/tizira/directional/north,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -68,18 +68,18 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "jC" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "lf" = (
 /obj/structure/fluff/paper/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "lp" = (
 /obj/effect/turf_decal/weather/sand{
 	color = "#662e2b"
@@ -87,41 +87,41 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "lO" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "lV" = (
 /obj/structure/fireplace,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "lZ" = (
 /obj/structure/fluff/paper{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "mD" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "nb" = (
 /obj/structure/flora/grass/both,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "nM" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "oK" = (
 /obj/effect/turf_decal/weather/sand{
 	color = "#662e2b";
@@ -130,7 +130,7 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "pc" = (
 /obj/effect/turf_decal/weather/sand{
 	color = "#662e2b";
@@ -139,23 +139,23 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "pd" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "pe" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "pA" = (
 /obj/structure/flora/grass/green/style_2,
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "pP" = (
 /obj/structure/fluff/paper{
 	dir = 8
@@ -163,7 +163,7 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "qy" = (
 /obj/structure/sign/poster/contraband/the_griffin/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -171,14 +171,14 @@
 	},
 /obj/structure/fluff/paper/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qY" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/structure/fluff/paper{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "rD" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
@@ -186,24 +186,24 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "rN" = (
 /obj/structure/fluff/paper/corner{
 	dir = 8
 	},
 /turf/closed/indestructible/paper,
-/area/space)
+/area/centcom/tdome/arena)
 "sQ" = (
 /turf/open/misc/sandy_dirt{
 	color = "#ad4b45"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "sX" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "tH" = (
 /obj/structure/fluff/paper{
 	dir = 1
@@ -211,7 +211,7 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "tP" = (
 /obj/effect/turf_decal/weather/sand{
 	color = "#662e2b";
@@ -220,7 +220,7 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "vy" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -229,7 +229,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "vZ" = (
 /obj/structure/sign/poster/contraband/smoke/directional/north,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -240,12 +240,12 @@
 	},
 /obj/item/paper/crumpled,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "wC" = (
 /obj/structure/flora/grass/both,
 /obj/structure/statue/sandstone/venus,
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "wF" = (
 /obj/structure/fluff/paper/corner{
 	dir = 4
@@ -253,41 +253,41 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "wS" = (
 /obj/structure/statue/sandstone/venus,
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "xc" = (
 /obj/item/paper/crumpled,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "xx" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "xC" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "xX" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "yQ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "yW" = (
 /obj/structure/sign/clock/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -298,58 +298,58 @@
 	},
 /obj/structure/fluff/paper,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "zs" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
 	},
 /obj/item/light/tube/broken,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "zG" = (
 /obj/structure/fluff/paper{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ai" = (
 /turf/closed/indestructible/paper,
-/area/space)
+/area/centcom/tdome/arena)
 "Au" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /obj/structure/fluff/paper,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Bk" = (
 /obj/structure/flora/bush/fullgrass/style_3,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Bm" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "Cu" = (
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Dk" = (
 /obj/structure/fluff/paper/corner{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Et" = (
 /obj/structure/mannequin/plastic,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "GH" = (
 /obj/structure/sign/flag/ssc/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -357,7 +357,7 @@
 	},
 /obj/structure/fluff/paper,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "IJ" = (
 /obj/structure/fluff/paper{
 	dir = 4
@@ -365,21 +365,21 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "IS" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
 /obj/item/light/bulb/broken,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Ja" = (
 /obj/structure/flora/grass/jungle/b/style_random,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "JI" = (
 /obj/item/flashlight/lamp/bananalamp{
 	pixel_x = -4;
@@ -393,37 +393,37 @@
 /turf/open/misc/sandy_dirt{
 	color = "#ad4b45"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Kn" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Ko" = (
 /obj/structure/mannequin/plastic,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "LB" = (
 /obj/structure/flora/bush/fullgrass,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Ng" = (
 /obj/structure/flora/bush/lavendergrass/style_2,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Nu" = (
 /obj/structure/flora/grass/both/style_random,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "NN" = (
 /obj/structure/sign/flag/tizira/directional/north,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -431,26 +431,26 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "NU" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "OO" = (
 /obj/item/paper/crumpled/bloody,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "OU" = (
 /obj/structure/displaycase/trophy,
 /obj/item/reagent_containers/cup/glass/trophy/gold_cup,
 /turf/open/misc/sandy_dirt{
 	color = "#ad4b45"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Pu" = (
 /obj/structure/fluff/paper{
 	dir = 1
@@ -459,7 +459,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Pw" = (
 /obj/effect/turf_decal/weather/sand{
 	color = "#662e2b";
@@ -468,20 +468,20 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Qz" = (
 /obj/structure/flora/grass/green/style_3,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "QQ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Rj" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
@@ -490,68 +490,68 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Rz" = (
 /obj/structure/flora/grass/jungle/b/style_random,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "RJ" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "Tk" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "TA" = (
 /obj/structure/fluff/paper,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "TD" = (
 /obj/structure/flora/grass/jungle/a/style_3,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "Uu" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "UW" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Vg" = (
 /obj/structure/fluff/paper/corner,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "VP" = (
 /obj/structure/flora/grass/both,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "WM" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Xe" = (
 /obj/effect/turf_decal/weather/sand{
 	color = "#662e2b";
@@ -560,7 +560,7 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "XK" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/fluff/paper/corner{
@@ -569,16 +569,16 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Yi" = (
 /turf/open/misc/ashplanet/wateryrock,
-/area/space)
+/area/centcom/tdome/arena)
 "Zj" = (
 /obj/structure/fluff/paper,
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Zp" = (
 /obj/effect/turf_decal/weather/sand{
 	color = "#662e2b";
@@ -587,7 +587,7 @@
 /turf/open/misc/dirt{
 	color = "#9e6b59"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 
 (1,1,1) = {"
 wS

--- a/_maps/toolbox_arenas/arena_raven.dmm
+++ b/_maps/toolbox_arenas/arena_raven.dmm
@@ -10,7 +10,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "bU" = (
 /obj/item/cigbutt{
 	pixel_x = 2;
@@ -21,19 +21,19 @@
 	pixel_y = 19
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cg" = (
 /obj/effect/turf_decal/raven/six,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ch" = (
 /obj/machinery/oven/range,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "cj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/space)
+/area/centcom/tdome/arena)
 "dl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -41,12 +41,12 @@
 	pixel_y = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "dn" = (
 /obj/structure/fluff/paper,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ds" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt{
@@ -54,7 +54,7 @@
 	pixel_y = -7
 	},
 /turf/open/floor/iron/smooth,
-/area/space)
+/area/centcom/tdome/arena)
 "dC" = (
 /obj/structure/fluff/paper{
 	dir = 10
@@ -65,7 +65,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "fb" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
@@ -74,32 +74,32 @@
 	icon = 'icons/turf/walls.dmi';
 	icon_state = "paperwall"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "fx" = (
 /obj/item/kirbyplants/fern{
 	pixel_x = -6;
 	pixel_y = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "fQ" = (
 /obj/effect/turf_decal/raven/three,
 /obj/structure/fluff/paper/stack{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "fU" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "gZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "hv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt{
@@ -107,7 +107,7 @@
 	pixel_y = -7
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "hT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt{
@@ -119,7 +119,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "id" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
@@ -129,64 +129,64 @@
 	pixel_y = -7
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "iM" = (
 /turf/open/floor/iron/smooth,
-/area/space)
+/area/centcom/tdome/arena)
 "lH" = (
 /obj/structure/bed/maint,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "lL" = (
 /obj/effect/turf_decal/raven/two,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "lT" = (
 /obj/item/cigbutt{
 	pixel_x = 2;
 	pixel_y = 13
 	},
 /turf/open/floor/iron/smooth,
-/area/space)
+/area/centcom/tdome/arena)
 "lY" = (
 /obj/item/cigbutt{
 	pixel_x = -12;
 	pixel_y = -7
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "mW" = (
 /obj/structure/fluff/paper{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "nh" = (
 /turf/closed/wall{
 	opacity = 0
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "nm" = (
 /obj/structure/fluff/paper,
 /obj/structure/fluff/paper/stack{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "nK" = (
 /obj/structure/fluff/paper{
 	dir = 1
 	},
 /obj/structure/fluff/paper,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "oV" = (
 /obj/structure/fluff/paper{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "pd" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
@@ -194,46 +194,46 @@
 /obj/structure/fluff/paper,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "pj" = (
 /obj/structure/table/wood,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "pL" = (
 /obj/effect/turf_decal/raven/seven,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qe" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/tgc{
 	pixel_x = 3
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qx" = (
 /obj/structure/fluff/paper/stack{
 	dir = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "rr" = (
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "rH" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
-/area/space)
+/area/centcom/tdome/arena)
 "rR" = (
 /obj/structure/fluff/paper{
 	dir = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "sx" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/tcomms{
@@ -241,7 +241,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "sG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/fern{
@@ -249,7 +249,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "va" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -262,11 +262,11 @@
 	pixel_y = 3
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "vx" = (
 /obj/effect/turf_decal/raven/four,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "vy" = (
 /obj/structure/fluff/paper/corner{
 	dir = 4
@@ -278,14 +278,14 @@
 	},
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "wm" = (
 /obj/effect/turf_decal/raven/one,
 /obj/structure/fluff/paper/stack{
 	dir = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "wD" = (
 /obj/structure/fluff/paper{
 	dir = 8
@@ -295,7 +295,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "xc" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -307,7 +307,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "xR" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -315,12 +315,12 @@
 	pixel_y = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ye" = (
 /obj/structure/fluff/paper/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ys" = (
 /obj/item/flashlight/lamp/green{
 	pixel_x = -3;
@@ -340,7 +340,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "yD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -348,28 +348,28 @@
 	pixel_y = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "yE" = (
 /obj/structure/fluff/paper/stack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "zh" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Bg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/iron/smooth,
-/area/space)
+/area/centcom/tdome/arena)
 "FE" = (
 /obj/structure/fluff/paper/stack{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "FS" = (
 /obj/structure/fluff/paper/corner{
 	dir = 8
@@ -380,20 +380,20 @@
 	pixel_y = 7
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "IA" = (
 /obj/effect/turf_decal/raven/eight,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "JF" = (
 /turf/open/floor/carpet,
-/area/space)
+/area/centcom/tdome/arena)
 "JH" = (
 /obj/structure/fluff/paper/stack{
 	dir = 10
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "JN" = (
 /obj/structure/table/wood,
 /obj/item/pen{
@@ -401,16 +401,16 @@
 	pixel_y = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Lz" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Np" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "NF" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -419,11 +419,11 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "PY" = (
 /obj/effect/turf_decal/raven/five,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Qi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -432,36 +432,36 @@
 	pixel_y = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "QO" = (
 /obj/effect/turf_decal/raven/nine,
 /obj/structure/fluff/paper/stack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "TN" = (
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "TQ" = (
 /obj/item/cigbutt{
 	pixel_x = 10;
 	pixel_y = -6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "TV" = (
 /obj/structure/fluff/paper{
 	dir = 10
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Vp" = (
 /obj/item/cigbutt{
 	pixel_x = 2;
 	pixel_y = 13
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Vw" = (
 /obj/structure/table/wood,
 /obj/item/folder/syndicate{
@@ -469,7 +469,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "VR" = (
 /obj/structure/fluff/paper/stack{
 	dir = 5
@@ -478,7 +478,7 @@
 	icon = 'icons/turf/walls.dmi';
 	icon_state = "paperwall"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "YK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt{
@@ -486,13 +486,13 @@
 	pixel_y = 13
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ZI" = (
 /turf/open/floor/stone{
 	icon = 'icons/turf/walls.dmi';
 	icon_state = "paperwall"
 	},
-/area/space)
+/area/centcom/tdome/arena)
 
 (1,1,1) = {"
 cj

--- a/_maps/toolbox_arenas/arena_sewers.dmm
+++ b/_maps/toolbox_arenas/arena_sewers.dmm
@@ -4,18 +4,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth_corner,
-/area/space)
+/area/centcom/tdome/arena)
 "fK" = (
 /obj/structure/railing,
 /obj/item/cigbutt{
 	pixel_x = -13
 	},
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "hf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "hB" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -24,30 +24,30 @@
 	pixel_y = 2
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "hN" = (
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "hW" = (
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "if" = (
 /obj/structure/railing/corner/end{
 	dir = 4
 	},
 /turf/open/floor/iron/smooth_corner,
-/area/space)
+/area/centcom/tdome/arena)
 "ii" = (
 /obj/structure/lattice/catwalk,
 /mob/living/basic/mouse/brown,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "iG" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "md" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -61,7 +61,7 @@
 	pixel_y = -4
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "nl" = (
 /obj/structure/lattice/catwalk,
 /obj/item/ammo_casing/spent{
@@ -69,7 +69,7 @@
 	pixel_y = -4
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "oK" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -78,56 +78,56 @@
 	pixel_y = 16
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "oR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/flare,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "pj" = (
 /mob/living/basic/cockroach,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "pG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/mouse,
 /turf/open/floor/iron/smooth_corner,
-/area/space)
+/area/centcom/tdome/arena)
 "pI" = (
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "qw" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/cockroach,
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "qH" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/mouse,
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "rc" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/mouse/white,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "ru" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "rE" = (
 /obj/item/cigbutt{
 	pixel_x = -13
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "sv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_corner{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "sw" = (
 /obj/structure/railing/corner/end{
 	dir = 4
@@ -136,7 +136,7 @@
 /turf/open/floor/iron/smooth_corner{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "ti" = (
 /mob/living/basic/cockroach,
 /obj/item/ammo_casing/spent{
@@ -144,7 +144,7 @@
 	pixel_y = -9
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "us" = (
 /obj/item/wirecutters{
 	pixel_y = 6
@@ -152,29 +152,29 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "uu" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/cockroach,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "uz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "uP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/tray,
 /turf/open/floor/iron/smooth_corner{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "vd" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "vq" = (
 /obj/structure/lattice/catwalk,
 /mob/living/basic/cockroach,
@@ -183,7 +183,7 @@
 	pixel_y = -5
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "wW" = (
 /obj/item/cigbutt{
 	pixel_x = -13;
@@ -192,27 +192,27 @@
 /turf/open/floor/iron/smooth_corner{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "xe" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "xH" = (
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "yy" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/mouse/brown,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "yC" = (
 /obj/item/ammo_casing/spent{
 	pixel_x = 3;
 	pixel_y = -9
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "yM" = (
 /obj/structure/lattice/catwalk,
 /obj/item/cigbutt{
@@ -220,7 +220,7 @@
 	pixel_y = -5
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "zc" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -229,31 +229,31 @@
 	pixel_y = 3
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "zk" = (
 /obj/item/cigbutt{
 	pixel_x = -13;
 	pixel_y = 16
 	},
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "zs" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/cockroach,
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "zO" = (
 /obj/item/cigbutt{
 	pixel_x = -13
 	},
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "zS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Bm" = (
 /obj/item/cigbutt{
 	pixel_x = -11;
@@ -262,7 +262,7 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Cp" = (
 /obj/structure/lattice/catwalk,
 /obj/item/ammo_casing/spent{
@@ -270,16 +270,16 @@
 	pixel_y = -4
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "EC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "EJ" = (
 /turf/open/floor/iron/smooth_corner{
 	dir = 4
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "EX" = (
 /obj/structure/lattice/catwalk,
 /obj/item/ammo_casing/spent{
@@ -287,24 +287,24 @@
 	pixel_y = 9
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "Gg" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "Gr" = (
 /turf/open/floor/iron/smooth_large,
-/area/space)
+/area/centcom/tdome/arena)
 "Hc" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "Ih" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "Jf" = (
 /obj/item/ammo_casing/spent{
 	pixel_x = 3;
@@ -313,7 +313,7 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "Jj" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 8
@@ -322,30 +322,30 @@
 /turf/open/floor/iron/smooth_corner{
 	dir = 8
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "JU" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/cockroach,
 /turf/open/floor/iron/smooth_large,
-/area/space)
+/area/centcom/tdome/arena)
 "KZ" = (
 /obj/structure/lattice/catwalk,
 /mob/living/basic/cockroach,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "NH" = (
 /obj/structure/railing,
 /turf/open/floor/iron/smooth_half,
-/area/space)
+/area/centcom/tdome/arena)
 "PJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "QP" = (
 /obj/structure/railing,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "Rp" = (
 /obj/structure/lattice/catwalk,
 /obj/item/cigbutt{
@@ -353,11 +353,11 @@
 	pixel_y = 16
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "RX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "SG" = (
 /obj/structure/lattice/catwalk,
 /obj/item/ammo_casing/spent{
@@ -365,24 +365,24 @@
 	pixel_y = 9
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "TB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/chips,
 /turf/open/floor/iron/smooth_corner{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "UZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
-/area/space)
+/area/centcom/tdome/arena)
 "Vc" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/smooth_corner{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "YL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/cnds{
@@ -390,7 +390,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/centcom/tdome/arena)
 "Zn" = (
 /obj/structure/lattice/catwalk,
 /obj/item/trash/sosjerky{
@@ -398,7 +398,7 @@
 	pixel_y = -4
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 "Zp" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -406,7 +406,7 @@
 	pixel_x = -13
 	},
 /turf/open/water,
-/area/space)
+/area/centcom/tdome/arena)
 
 (1,1,1) = {"
 YL

--- a/_maps/toolbox_arenas/arena_tiki.dmm
+++ b/_maps/toolbox_arenas/arena_tiki.dmm
@@ -1,108 +1,108 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/open/misc/beach/sand,
-/area/space)
+/area/centcom/tdome/arena)
 "d" = (
 /obj/structure/flora/tree/palm/style_2,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/grass/jungle,
-/area/space)
+/area/centcom/tdome/arena)
 "e" = (
 /obj/item/stock_parts/cell/lead,
 /turf/open/water/beach,
-/area/space)
+/area/centcom/tdome/arena)
 "g" = (
 /obj/item/toy/seashell,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/centcom/tdome/arena)
 "h" = (
 /turf/open/misc/beach/coast/corner{
 	dir = 1
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "m" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/grass/jungle,
-/area/space)
+/area/centcom/tdome/arena)
 "p" = (
 /obj/structure/flora/coconuts,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/centcom/tdome/arena)
 "u" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/item/chair/plastic,
 /obj/item/storage/cans/sixbeer,
 /turf/open/misc/grass/jungle,
-/area/space)
+/area/centcom/tdome/arena)
 "v" = (
 /obj/item/flashlight/flare/torch{
 	on = 1
 	},
 /turf/open/misc/beach/sand,
-/area/space)
+/area/centcom/tdome/arena)
 "x" = (
 /mob/living/simple_animal/pet/gondola,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/item/storage/toolbox/fishing,
 /obj/item/clothing/head/soft/fishing_hat,
 /turf/open/misc/grass/jungle,
-/area/space)
+/area/centcom/tdome/arena)
 "y" = (
 /turf/open/water/beach,
-/area/space)
+/area/centcom/tdome/arena)
 "C" = (
 /turf/open/misc/beach/coast/corner,
-/area/space)
+/area/centcom/tdome/arena)
 "D" = (
 /obj/structure/bonfire/prelit,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/centcom/tdome/arena)
 "G" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/punji_sticks/spikes,
 /turf/open/misc/grass/jungle,
-/area/space)
+/area/centcom/tdome/arena)
 "I" = (
 /turf/open/misc/beach/coast{
 	dir = 6
 	},
-/area/space)
+/area/centcom/tdome/arena)
 "J" = (
 /obj/structure/flora/tree/palm,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/grass/jungle,
-/area/space)
+/area/centcom/tdome/arena)
 "K" = (
 /turf/open/misc/beach/coast,
-/area/space)
+/area/centcom/tdome/arena)
 "N" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/misc/grass/jungle,
-/area/space)
+/area/centcom/tdome/arena)
 "O" = (
 /mob/living/basic/crab,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/centcom/tdome/arena)
 "T" = (
 /obj/item/clothing/mask/gas/tiki_mask,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/centcom/tdome/arena)
 "U" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/item/fishing_rod,
 /obj/item/fishing_hook/shiny,
 /turf/open/misc/grass/jungle,
-/area/space)
+/area/centcom/tdome/arena)
 "X" = (
 /obj/item/ritual_totem,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/centcom/tdome/arena)
 "Z" = (
 /turf/open/misc/beach/coast{
 	dir = 10
 	},
-/area/space)
+/area/centcom/tdome/arena)
 
 (1,1,1) = {"
 m


### PR DESCRIPTION
This was monkey patched on the live event, but uploading here too